### PR TITLE
Update pluginuploader.php

### DIFF
--- a/files/inc/plugins/pluginuploader.php
+++ b/files/inc/plugins/pluginuploader.php
@@ -64,7 +64,7 @@ function pluginuploader_install()
 				`name` VARCHAR(255) NOT NULL UNIQUE KEY,
 				`version` VARCHAR(25) NOT NULL ,
 				`files` TEXT NOT NULL
-			) ENGINE = MYISAM ;
+			) ENGINE = INNODB ROW_FORMAT=DYNAMIC;
 		");
 	}
 


### PR DESCRIPTION
The original query produces a `1071 - Specified key was too long; max key length is 1000 bytes error`.
Changing line 67 to `ENGINE = INNODB ROW_FORMAT=DYNAMIC;` makes the error dissapear.
#5 